### PR TITLE
Add a script for setting up the HTTP service

### DIFF
--- a/files/setup_http_service.sh
+++ b/files/setup_http_service.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+
+# These variables must be set before client installation:
+#
+# hostname: The hostname of this IPA client (e.g. client.example.com).
+
+# The file installed by cloud-init that contains the value for the
+# above variables.
+freeipa_vars_file=/var/lib/cloud/instance/freeipa-vars.sh
+
+# Load above variable from a file installed by cloud-init:
+if [[ -f "$freeipa_vars_file" ]]
+then
+    # Disable this warning since the file is only available at runtime
+    # on the server.
+    #
+    # shellcheck disable=SC1090
+    source "$freeipa_vars_file"
+else
+    echo "FreeIPA variables file does not exist: $freeipa_vars_file"
+    echo "It should have been created by cloud-init at boot."
+    exit 254
+fi
+
+# Get the default Ethernet interface
+function get_interface {
+    ip route | grep default | sed "s/^.* dev \([^ ]*\).*$/\1/"
+}
+
+# Get the IP address corresponding to an interface
+function get_ip {
+    ip --family inet address show dev "$1" | \
+        grep --perl-regexp --only-matching 'inet \K[\d.]+'
+}
+
+# Create the HTTP/$hostname service if it does not already exist.
+#
+# Since the service may not be found, which returns an error code, we
+# need to temporarily turn off errexit for this.
+set +o errexit
+# hostname is defined in the FreeIPA variables file that is sourced
+# toward the top of this file.  Hence we can ignore the "undefined
+# variable" warning from shellcheck.
+#
+# shellcheck disable=SC2154
+ipa service-find --canonical-principal="HTTP/$hostname"
+rc=$?
+set -o errexit
+if [[ $rc -ne 0 ]]
+then
+    ipa service-add "HTTP/$hostname"
+    # Grab our IP address
+    interface=$(get_interface)
+    ip_address=$(get_ip "$interface")
+    ip_address_dashes=${ip_address//./-}
+    # Add an alias that is the PTR record as determined from the
+    # Shared Services VPC.
+    ipa service-add-principal "HTTP/$hostname" "HTTP/ip-${ip_address_dashes}.ec2.internal"
+fi
+
+# Grab the keytab for the HTTP service
+ipa-getkeytab --quiet --keytab=/etc/krb5.keytab --principal="HTTP/$hostname"

--- a/files/setup_http_service.sh
+++ b/files/setup_http_service.sh
@@ -4,6 +4,10 @@ set -o nounset
 set -o errexit
 set -o pipefail
 
+# This script is intended to set up the HTTP FreeIPA service on this
+# host.  It creates the service if it does not already exist, then
+# retrieves and saves the keytab.
+#
 # These variables must be set before client installation:
 #
 # hostname: The hostname of this IPA client (e.g. client.example.com).

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -53,3 +53,13 @@ def test_services(host):
         service = "httpd"
 
     assert host.service(service).is_enabled
+
+
+@pytest.mark.parametrize("f", ["/usr/local/sbin/setup_http_service.sh"])
+def test_files(host, f):
+    """Test that the expected files were installed."""
+    assert host.file(f).exists
+    assert host.file(f).is_file
+    assert host.file(f).user == "root"
+    assert host.file(f).group == "root"
+    assert host.file(f).mode == 0o700

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -21,3 +21,9 @@
   service:
     name: "{{ httpd_service_name }}"
     enabled: yes
+
+- name: Copy setup script
+  copy:
+    src: setup_http_service.sh
+    dest: /usr/local/sbin
+    mode: 0700


### PR DESCRIPTION
## 🗣 Description

This pull request adds a script for setting up the HTTP FreeIPA service.

## 💭 Motivation and Context

The HTTP FreeIPA service must be set up if we are to Kerberize guacamole.

## 🧪 Testing

I ran the script on the guacamole server in our `env0` staging environment, both with and without the HTTP service already present on the FreeIPA server.  Everything worked as expected.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
