### PR TITLE
Modifications necessary for kerberization of guacamole

### DIFF
--- a/files/setup_http_service.sh
+++ b/files/setup_http_service.sh
@@ -66,5 +66,8 @@ then
     ipa service-add-principal "HTTP/$hostname" "HTTP/ip-${ip_address_dashes}.ec2.internal"
 fi
 
-# Grab the keytab for the HTTP service
-ipa-getkeytab --quiet --keytab=/etc/krb5.keytab --principal="HTTP/$hostname"
+# Grab the keytab for the HTTP service and change its permissions so
+# that the httpd process can read it.
+ipa-getkeytab --quiet --keytab=/etc/krb5_http.keytab --principal="HTTP/$hostname"
+chgrp www-data /etc/krb5_http.keytab
+chmod g+r /etc/krb5_http.keytab

--- a/files/setup_http_service.sh
+++ b/files/setup_http_service.sh
@@ -71,3 +71,6 @@ fi
 ipa-getkeytab --quiet --keytab=/etc/krb5_http.keytab --principal="HTTP/$hostname"
 chgrp www-data /etc/krb5_http.keytab
 chmod g+r /etc/krb5_http.keytab
+
+# Restart the httpd systemd service
+systemctl restart apache2.service

--- a/molecule/default/tests/test_default.py
+++ b/molecule/default/tests/test_default.py
@@ -25,7 +25,17 @@ def test_debian_packages(host, pkg):
         assert host.package(pkg).is_installed
 
 
-@pytest.mark.parametrize("pkg", ["httpd", "mod_auth_gssapi", "mod_authnz_pam"])
+@pytest.mark.parametrize(
+    "pkg",
+    [
+        "httpd",
+        "mod_auth_gssapi",
+        "mod_authnz_pam",
+        "mod_proxy_html",
+        "mod_session",
+        "mod_ssl",
+    ],
+)
 def test_redhat_packages(host, pkg):
     """Test that the appropriate packages were installed."""
     if (

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -33,6 +33,10 @@
     - ssl
   when: ansible_os_family != "RedHat"
 
+- name: Systemd daemon-reload
+  systemd:
+    daemon_reload: true
+
 - name: Enable httpd
   service:
     name: "{{ httpd_service_name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,9 +13,25 @@
       paths:
         - "{{ role_path }}/vars"
 
-- name: Install httpd with mod_auth_gssapi and mod_authnz_pam
+- name: Install httpd with modules needed to create a kerberized proxy
   package:
     name: "{{ httpd_package_names }}"
+
+# On RedHat these modules are already enabled, and apache2_module does
+# not work there, so we only run this task on non-RedHat hosts.
+- name: Enable some httpd modules
+  apache2_module:
+    name: "{{ item }}"
+  loop:
+    - auth_gssapi
+    - authnz_pam
+    - headers
+    - proxy
+    - proxy_http
+    - session
+    - session_cookie
+    - ssl
+  when: ansible_os_family != "RedHat"
 
 - name: Enable httpd
   service:

--- a/vars/RedHat.yml
+++ b/vars/RedHat.yml
@@ -6,6 +6,9 @@ httpd_package_names:
   - httpd
   - mod_auth_gssapi
   - mod_authnz_pam
+  - mod_proxy_html
+  - mod_session
+  - mod_ssl
 
 # The name of the httpd systemd service
 httpd_service_name: httpd


### PR DESCRIPTION
## 🗣 Description

This pull request makes several modifications necessary for the successful kerberization of guacamole.  These include:
* Add some necessary-but-missing httpd modules
* Ensure all necessary httpd modules are enabled
* Save the HTTP service keytab to its own file.  httpd does not require access to the host keytab.
* Add a restart for the httpd service so that it can take advantage of the keytab once it becomes available.

See also:
* cisagov/guacamole-composition#9
* cisagov/cool-assessment-terraform#58
* cisagov/ansible-role-guacamole#6

## 💭 Motivation and Context

Guacamole must be kerberized in the COOL.

## 🧪 Testing

I have used these changes to successfully deploy a kerberized version of guacamole to env0 in our staging environment.

## 🚥 Types of Changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
