### PR TITLE
Enable the proxy_wstunnel module for Apache

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,6 +28,7 @@
     - headers
     - proxy
     - proxy_http
+    - proxy_wstunnel
     - session
     - session_cookie
     - ssl


### PR DESCRIPTION
## 🗣 Description

This pull request enables the `proxy_wstunnel` module for Apache webserver.

## 💭 Motivation and Context

This module is required to proxy websocket traffic, e.g. for Guacamole.

## 🧪 Testing

All pre-commit hooks and molecule tests pass.

## 🚥 Types of Changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (causes existing functionality to change)

## ✅ Checklist

- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
