### PR TITLE
Add optional argument for group allowed to create keytab

### DIFF
--- a/files/01_setup_http_service.sh
+++ b/files/01_setup_http_service.sh
@@ -13,12 +13,12 @@ set -o pipefail
 # hostname: The hostname of this IPA client (e.g. client.example.com).
 
 USAGE=$(
-  cat << 'END_OF_LINE'
+  cat << END_OF_LINE
 Set up the HTTP FreeIPA service on this host.
 
 Usage:
-  01_setup_http_service.sh [IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB]
-  01_setup_http_service.sh (-h | --help)
+  ${0##*/} [IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB]
+  ${0##*/} (-h | --help)
 
 END_OF_LINE
 )

--- a/files/01_setup_http_service.sh
+++ b/files/01_setup_http_service.sh
@@ -90,7 +90,7 @@ fi
 
 # If an IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB argument was provided,
 # add that group to the service.
-if [ $# -eq 1 ]; then
+if [ -v group_allowed_to_create_keytab ]; then
   ipa service-allow-create-keytab "HTTP/$hostname" --groups="$group_allowed_to_create_keytab"
 fi
 

--- a/files/01_setup_http_service.sh
+++ b/files/01_setup_http_service.sh
@@ -12,6 +12,30 @@ set -o pipefail
 #
 # hostname: The hostname of this IPA client (e.g. client.example.com).
 
+USAGE=$(
+  cat << 'END_OF_LINE'
+Set up the HTTP FreeIPA service on this host.
+
+Usage:
+  01_setup_http_service.sh [IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB]
+  01_setup_http_service.sh (-h | --help)
+
+END_OF_LINE
+)
+
+# Parse command line arguments
+if [ $# -eq 1 ]; then
+  if [ "$1" == "-h" ] || [ "$1" == "--help" ]; then
+    echo "${USAGE}"
+    exit 0
+  else
+    group_allowed_to_create_keytab=$1
+  fi
+elif [ $# -gt 1 ]; then
+  echo "${USAGE}"
+  exit 1
+fi
+
 # The file installed by cloud-init that contains the value for the
 # above variables.
 freeipa_vars_file=/var/lib/cloud/instance/freeipa-vars.sh
@@ -62,6 +86,12 @@ if [[ $rc -ne 0 ]]; then
   # Add an alias that is the PTR record as determined from the
   # Shared Services VPC.
   ipa service-add-principal "HTTP/$hostname" "HTTP/ip-${ip_address_dashes}.ec2.internal"
+fi
+
+# If an IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB argument was provided,
+# add that group to the service.
+if [ $# -eq 1 ]; then
+  ipa service-allow-create-keytab "HTTP/$hostname" --groups="$group_allowed_to_create_keytab"
 fi
 
 # Grab the keytab for the HTTP service and change its permissions so


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This PR adds a new optional `IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB` argument to the `[01_setup_http_service.sh](https://github.com/cisagov/ansible-role-httpd/blob/develop/files/01_setup_http_service.sh)` script.  If that argument is present, the specified IPA group is added to the HTTP service with the "Allowed to create keytab" permission.

I also added some logic to display helpful usage text for `01_setup_http_service.sh`.

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

If the user running the `[01_setup_http_service.sh](https://github.com/cisagov/ansible-role-httpd/blob/develop/files/01_setup_http_service.sh)` script does not have the appropriate permissions, they will receive an error like this when `ipa-getkeytab` is run for the newly-created HTTP service:

```
Failed to parse result: Insufficient access rights

Failed to retrieve encryption type Camellia-128 CTS mode with CMAC (#25)
Failed to retrieve encryption type Camellia-256 CTS mode with CMAC (#26)
```

The solution is to ensure that the user is a member of an IPA group with [`Service Administrators` privilege](https://docs.fedoraproject.org/en-US/Fedora/18/html/FreeIPA_Guide/defining-roles.html) and ensure that they provide that group name as an argument to the `01_setup_http_service.sh` script.

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

I tested this script to ensure that it works as intended (i.e. without errors) for both an admin user and a user that must supply the optional `IPA-GROUP-ALLOWED-TO-CREATE-KEYTAB` argument.  I also confirmed that the usage text appears if more than one argument is supplied or if the only argument is `-h` or `--help`.

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated
      to reflect the changes in this PR.
- [x] All new and existing tests pass.
